### PR TITLE
feat: Add Prefab mode context support to McpUnifiedObjectTool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.sack-kazu.unity-natural-mcp-extension-tools",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "displayName": "Unity Natural MCP Extension Tools",
   "description": "Unified extension tools for Unity Natural MCP with prefab editing functionality",
   "author": {


### PR DESCRIPTION
## Summary

Add comprehensive Prefab editing mode support to McpUnifiedObjectTool, enabling all object manipulation methods to work seamlessly within Unity's Prefab editing context.

## Changes

- ✨ **New Parameter**: Add `inPrefabMode` parameter to all object manipulation methods:
  - `CreateObject` - Create objects within Prefab editing context
  - `ManipulateObject` - Transform, parent, duplicate, delete operations in Prefab mode
  - `ConfigureComponent` - Add/configure components on Prefab objects
  - `GetObjectInfo` - Inspect Prefab objects and their properties
  - `ListSceneObjects` - List objects within Prefab editing context

- 🔧 **Enhanced Object Finding**: Add `FindGameObjectInContext` helper method for unified object searching across scene and Prefab contexts

- 📝 **Proper Scene Management**: Implement appropriate scene dirty marking for both scene and Prefab editing modes using `PrefabStageUtility`

- 🚀 **Version Bump**: Update package version to 0.5.0 to reflect new functionality

## Technical Details

- Utilizes `UnityEditor.Experimental.SceneManagement.PrefabStageUtility` for Prefab stage detection and management
- Maintains backward compatibility with default `inPrefabMode = false` parameter
- Enhanced error messages indicate context (scene vs Prefab mode) for better debugging
- Proper integration with Unity's Undo system for both contexts

## Test Plan

- [ ] Test object creation in both scene and Prefab contexts
- [ ] Verify object manipulation (transform, parent, duplicate, delete) works in Prefab mode
- [ ] Confirm component configuration functions correctly in Prefab editing
- [ ] Validate object listing and information retrieval in Prefab context
- [ ] Ensure backward compatibility with existing scene-only workflows

🤖 Generated with [Claude Code](https://claude.ai/code)